### PR TITLE
encapsulated pointer + size constructs into std::span

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ u4->x = 5; //okay.
 This requires the source and destination types be trivially copyable.
 
 # zero_cost_serialization::invoke
-This method unpacks an aligned buffer and calls the supplied object with the templated arguments. The pack of types must be serializable. It is on the user to ensure the buffer is at least as strictly aligned as the types in the pack (see below example for conformant use). Data is passed by reference to the callable object though the parameters need not be reference parameters. Allowable parameters are 0 or more fixed size parameters and an optional unbounded array at the end modeling a variable length array. If the unbounded array is specified, the last 2 parameters are a pointer to the element type of the unbounded array, and a std::size_t n which is the number of elements created in the resulting buffer accessible through the pointer. If there is not enough data supplied to call the functor, the supplied data is copied to an aligned zeroed stack buffer which is used to call the functor. Returns the result of the functor.
+This method unpacks an aligned buffer and calls the supplied object with the templated arguments. The pack of types must be serializable. It is on the user to ensure the buffer is at least as strictly aligned as the types in the pack (see below example for conformant use). Data is passed by reference to the callable object though the parameters need not be reference parameters. Allowable parameters are 0 or more fixed size parameters and an optional unbounded array at the end modeling a variable length array. If the unbounded array is specified, the last parameter to the functor shall be a std::span. If there is not enough data supplied to call the functor, the supplied data is copied to an aligned zeroed stack buffer which is used to call the functor. Returns the result of the functor.
 
 ```
 template <typename... Ts>
 auto test() noexcept
 {
-	auto fun = [](const char*, std::uint32_t u, float f[], std::size_t n)
+	auto fun = [](const char*, std::uint32_t u, std::span<float> f)
 	{
 		std::cout << u << std::endl;	
-		for (auto i = std::size_t{}; i < n; ++i)
+		for (auto i = std::size_t{}; i < f.size(); ++i)
 			std::cout << f[i] << std::endl;
 	};
 	alignas(Ts...) std::byte buf[sizeof(std::uint32_t) + sizeof(float[2])]{};
@@ -126,8 +126,8 @@ test<std::uint32_t, float[]>();
 ```
 
 # zero_cost_serialization::apply
-This method is nearly identical to the above but unpacks a reflectable class of serializable members (basically, a C struct with no padding except potentially at the end) and calls a supplied functor over the members of the struct. If the final member of the struct should be treated as a flexible array of `std::add_reference_t<std::remove_extent_t<M>[]>` for some element member type M depends on the signature of the functor. If the supplied object is callable with
-a reference to the element types, it's a fixed size object. If the supplied object is callable with `std::add_pointer<std::remove_extent_t<M>>, std::size_t` as the final two parameters and all other parameters as references to the element types of T, then a variable size object is created in the buffer which has 0 or more Ts.
+This method is nearly identical to the above but unpacks a reflectable class of serializable members (basically, a C struct with no padding except potentially at the end) and calls a supplied functor over the members of the struct. If the final member of the struct should be treated as a flexible array of `std::remove_extent_t<M>[]` for some element member type M depends on the signature of the functor. If the supplied object is callable with
+a reference to the element types, it's a fixed size object. If the supplied object is callable with `std::span<std::remove_extent_t<M>>` as the final parameter and all other parameters as references to the element types of T, then a variable size object is created in the buffer which has 0 or more Ts.
 
 ```
 	struct foobar { std::uint32_t a; float b[2]; };
@@ -141,9 +141,9 @@ a reference to the element types, it's a fixed size object. If the supplied obje
 	std::memcpy(buf, "hello world", sizeof(buf));
 	zero_cost_serialization::apply<foobar>(fun, buf, sizeof(buf));
 
-	auto fun2 = [](std::uint32_t u, float p[], std::size_t n) {
+	auto fun2 = [](std::uint32_t u, std::span<float> p) {
 		std::cout << u << std::endl;
-		std::for_each_n(p, n, [](auto f) { std::cout << f << std::endl; });	
+		std::ranges::for_each(p, [](auto f) { std::cout << f << std::endl; });	
 	}; //std::uint32_t and 0+ floats.
 	std::memcpy(buf, "flex array!", sizeof(buf));
 	zero_cost_serialization::apply<foobar>(fun2, buf, sizeof(buf));

--- a/include/zero_cost_serialization/apply.h
+++ b/include/zero_cost_serialization/apply.h
@@ -25,7 +25,7 @@ namespace zero_cost_serialization {
 		}
 
 		template <typename T, typename F, typename Args>
-		requires is_unpack_invocable_v<F, T, Args>
+		requires (is_unpack_invocable_v<F, T, Args> and not is_unpack_invocable_flex_v<F, T, Args>)
 		[[nodiscard]] consteval auto apply_size() noexcept
 		{
 			if constexpr (empty_class<T>) {
@@ -75,14 +75,14 @@ namespace zero_cost_serialization {
 	}
 
 	template <zero_cost_serialization::detail::reflectable_class T, typename F>
-	requires detail::is_unpack_invocable_v<F, T>
+	requires (detail::is_unpack_invocable_v<F, T> and not detail::is_unpack_invocable_flex_v<F, T>)
 	decltype(auto) apply(F&& f, std::span<std::byte> data) noexcept(noexcept(detail::apply<F, std::tuple<>, detail::tuple_of_refs<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs<T>>>(), std::forward<F>(f), std::make_tuple(), data)))
 	{
 		return detail::apply<F, std::tuple<>, detail::tuple_of_refs<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs<T>>>(), std::forward<F>(f), std::make_tuple(), data);
 	}
 
 	template <zero_cost_serialization::detail::reflectable_class T, typename Args, typename F>
-	requires detail::is_unpack_invocable_v<F, T, Args>
+	requires (detail::is_unpack_invocable_v<F, T, Args> and not detail::is_unpack_invocable_flex_v<F, T, Args>)
 	decltype(auto) apply(F&& f, Args&& args, std::span<std::byte> data) noexcept(noexcept(detail::apply<F, Args, detail::tuple_of_refs<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs<T>>>(), std::forward<F>(f), std::forward<Args>(args), data)))
 	{
 		return detail::apply<F, Args, detail::tuple_of_refs<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs<T>>>(), std::forward<F>(f), std::forward<Args>(args), data);
@@ -90,16 +90,16 @@ namespace zero_cost_serialization {
 
 	template <zero_cost_serialization::detail::reflectable_class T, typename F>
 	requires detail::is_unpack_invocable_flex_v<F, T>
-	decltype(auto) apply(F&& f, std::span<std::byte> data) noexcept(noexcept(detail::apply<F, std::tuple<>, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex<T>>>(), std::forward<F>(f), std::make_tuple(), data)))
+	decltype(auto) apply(F&& f, std::span<std::byte> data) noexcept(noexcept(detail::apply<F, std::tuple<>, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex_span<T>>>(), std::forward<F>(f), std::make_tuple(), data)))
 	{
-		return detail::apply<F, std::tuple<>, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex<T>>>(), std::forward<F>(f), std::make_tuple(), data);
+		return detail::apply<F, std::tuple<>, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex_span<T>>>(), std::forward<F>(f), std::make_tuple(), data);
 	}
 
 	template <zero_cost_serialization::detail::reflectable_class T, typename Args, typename F>
 	requires detail::is_unpack_invocable_flex_v<F, T, Args>
-	decltype(auto) apply(F&& f, Args&& args, std::span<std::byte> data) noexcept(noexcept(detail::apply<F, Args, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex<T>>>(), std::forward<F>(f), std::forward<Args>(args), data)))
+	decltype(auto) apply(F&& f, Args&& args, std::span<std::byte> data) noexcept(noexcept(detail::apply<F, Args, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex_span<T>>>(), std::forward<F>(f), std::forward<Args>(args), data)))
 	{
-		return detail::apply<F, Args, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex<T>>>(), std::forward<F>(f), std::forward<Args>(args), data);
+		return detail::apply<F, Args, detail::tuple_of_refs_flex<T>>(std::make_index_sequence<std::tuple_size_v<detail::tuple_of_refs_flex_span<T>>>(), std::forward<F>(f), std::forward<Args>(args), data);
 	}
 }
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -153,10 +153,10 @@ static_assert(std::same_as<decltype(zero_cost_serialization::strict_alias_cast<c
 template <typename... Ts>
 auto test() noexcept
 {
-	auto fun = [](const char*, std::uint32_t u, zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>> p[], std::size_t n)
+	auto fun = [](const char*, std::uint32_t u, std::span<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>> p)
 	{
 		std::cout << u << std::endl;
-		std::for_each_n(p, n, [](float f) { std::cout << f << std::endl; });
+		std::ranges::for_each(p, [](float f) { std::cout << f << std::endl; });
 	};
 	alignas(Ts...) std::byte buf[12]{};
 	std::memcpy(buf, "hello world", sizeof(buf));
@@ -168,7 +168,7 @@ int main()
 	if constexpr (::is_zero_cost_serialization) {
 		struct TestFun
 		{
-			void operator()(std::uint_least32_t, bool) {}
+			void operator()(std::uint_least32_t, char) {}
 		};
 		struct TestFunT
 		{
@@ -244,9 +244,9 @@ int main()
 	static_assert(zero_cost_serialization::flex_element_size_v<foobar, decltype(fun)> == 0);
 	assert(73 == zero_cost_serialization::apply<foobar>(fun, buf));
 
-	auto fun2 = [](std::uint32_t uu, zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>> p[], std::size_t n) {
+	auto fun2 = [](std::uint32_t uu, std::span<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>> p) {
 		std::cout << uu << std::endl;
-		std::for_each_n(p, n, [](float ff) { std::cout << ff << std::endl; });
+		std::ranges::for_each(p, [](float ff) { std::cout << ff << std::endl; });
 	}; //std::uint32_t and 0+ floats.
 	std::memcpy(buf, "flex array!", sizeof(buf));
 	static_assert(zero_cost_serialization::apply_size_v<foobar, decltype(fun2)> == 4);


### PR DESCRIPTION
remove reinterpret cast from invoke
changed code to use span instead of pointer and implicitly related size parameter when emulating flexible array members.
The library will now use use std::span<T> instead of T[], std::size_t emulating flexible arrays in invoke/apply methods. Clang will still warn on -Wunsafe-buffer-usage due to using the two-parameter construction but the unsafe construction is regulated to library code limiting misuse. updated codegen to address clang warnings.
updated readme to reflect these changes.