### PR TITLE
fix additional safety issues from clang-20

### DIFF
--- a/include/zero_cost_serialization/apply.h
+++ b/include/zero_cost_serialization/apply.h
@@ -28,12 +28,11 @@ namespace zero_cost_serialization {
 		requires (is_unpack_invocable_v<F, T, Args> and not is_unpack_invocable_flex_v<F, T, Args>)
 		[[nodiscard]] consteval auto apply_size() noexcept
 		{
-			if constexpr (empty_class<T>) {
-				return invoke_size_pack<std::tuple<>>(std::make_index_sequence<0>());
-			} else {
+			if constexpr (not empty_class<T>) {
 				using TT = tuple_of_refs<T>;
 				return invoke_size_pack<TT>(std::make_index_sequence<std::tuple_size_v<TT>>());
-			}
+			} else
+				return invoke_size_pack<std::tuple<>>(std::make_index_sequence<0>());
 		}
 		template <typename T, typename F, typename Args>
 		requires is_unpack_invocable_flex_v<F, T, Args>
@@ -49,8 +48,8 @@ namespace zero_cost_serialization {
 			if constexpr (is_unpack_invocable_flex_v<F, T, Args>) {
 				using TT = tuple_of_refs_flex<T>;
 				return sizeof(std::remove_extent_t<std::remove_reference_t<std::tuple_element_t<std::tuple_size_v<TT> -1, TT>>>);
-			}
-			return std::size_t{};
+			} else
+				return std::size_t{};
 		}
 	}
 

--- a/include/zero_cost_serialization/bitfield.h
+++ b/include/zero_cost_serialization/bitfield.h
@@ -182,8 +182,10 @@ namespace zero_cost_serialization {
 		template <std::size_t N>
 		[[nodiscard]] static consteval auto offset() noexcept
 		{
-			if constexpr (not N) return common_type{};
-			else return offset(std::make_index_sequence<N>());
+			if constexpr (not N)
+				return common_type{};
+			else
+				return offset(std::make_index_sequence<N>());
 		}
 
 		template <std::size_t N>
@@ -210,7 +212,8 @@ namespace zero_cost_serialization {
 			auto unique = true;
 			auto i = sizeof...(Ts);
 			(find_index<T, Is>(i, unique), ...);
-			if (not unique) i = sizeof...(Ts);
+			if (not unique)
+				i = sizeof...(Ts);
 			return i;
 		}
 
@@ -441,8 +444,10 @@ namespace zero_cost_serialization {
 		requires (N < sizeof...(Ts))
 		constexpr auto set_value(const runtime_type<N>& value) noexcept
 		{
-			if constexpr (std::is_floating_point_v<runtime_type<N>>) set_integral<N>(zero_cost_serialization::from_float<int_type<N>, m_bits<N>, e_bits<N>>(value));
-			else set_integral<N>(value);
+			if constexpr (std::is_floating_point_v<runtime_type<N>>)
+				set_integral<N>(zero_cost_serialization::from_float<int_type<N>, m_bits<N>, e_bits<N>>(value));
+			else
+				set_integral<N>(value);
 		}
 
 		template <typename T>
@@ -456,8 +461,10 @@ namespace zero_cost_serialization {
 		requires (N < sizeof...(Ts))
 		[[nodiscard]] constexpr auto get_value() const noexcept
 		{
-			if constexpr (std::is_floating_point_v<runtime_type<N>>) return zero_cost_serialization::to_float<runtime_type<N>, m_bits<N>, e_bits<N>>(get_integral<N>());
-			else return get_integral<N>();
+			if constexpr (std::is_floating_point_v<runtime_type<N>>)
+				return zero_cost_serialization::to_float<runtime_type<N>, m_bits<N>, e_bits<N>>(get_integral<N>());
+			else
+				return get_integral<N>();
 		}
 
 		template <typename T>
@@ -553,8 +560,10 @@ namespace zero_cost_serialization {
 		template <typename T, std::size_t N>
 		[[nodiscard]] static constexpr auto contained_in_idx(const std::size_t byte) noexcept
 		{
-			if constexpr (not std::has_unique_object_representations_v<T> or std::endian::native not_eq std::endian::little) return false;
-			if (byte > bytes or bytes - byte < sizeof(T)) return false;
+			if constexpr (not std::has_unique_object_representations_v<T> or std::endian::native not_eq std::endian::little)
+				return false;
+			if (byte > bytes or bytes - byte < sizeof(T))
+				return false;
 			auto first_t = byte * std::numeric_limits<unsigned char>::digits;
 			auto last_t = first_t + std::numeric_limits<T>::digits;
 			return first_t <= offset<N>() and last_t >= offset<N>() + size<N>();
@@ -567,11 +576,14 @@ namespace zero_cost_serialization {
 			constexpr auto first = std::find_if(detail::integer_iterator{}, detail::integer_iterator{ byte_offset }, contained_in_idx<T, N>);
 			constexpr auto last = std::partition_point(first, detail::integer_iterator{ bytes }, contained_in_idx<T, N>);
 			if constexpr (not contained_in_idx<T, N>(*first)) return bytes;
-			else if constexpr (not aligned) return *first;
+			else if constexpr (not aligned)
+				return *first;
 			else {
 				static_assert(first not_eq last);
-				if constexpr (constexpr auto it = std::find_if(first, last, [](const auto i) { return not (i % alignof(T)); }); contained_in_idx<T, N>(*it)) return *it;
-				else return bytes;
+				if constexpr (constexpr auto it = std::find_if(first, last, [](const auto i) { return not (i % alignof(T)); }); contained_in_idx<T, N>(*it))
+					return *it;
+				else
+					return bytes;
 			}
 		}
 
@@ -590,8 +602,10 @@ namespace zero_cost_serialization {
 		template <std::size_t N>
 		[[nodiscard]] static consteval auto native_offset() noexcept
 		{
-			if constexpr (constexpr auto off = native_offset<N, native_type<N>, true>(); off not_eq bytes) return off;
-			else return native_offset<N, native_type<N>, false>();
+			if constexpr (constexpr auto off = native_offset<N, native_type<N>, true>(); off not_eq bytes) 
+				return off;
+			else 
+				return native_offset<N, native_type<N>, false>();
 		}
 
 		template <typename T, std::size_t N>
@@ -599,7 +613,7 @@ namespace zero_cost_serialization {
 		{
 			alignas(T) std::array<std::byte, sizeof(T)> v;
 			static_assert(std::has_unique_object_representations_v<decltype(v)>);
-			std::ranges::copy(std::span(s). template subspan<N, sizeof(T)>(), v.data());
+			std::ranges::copy(std::span(s). template subspan<N, sizeof(T)>(), v.begin());
 			return std::bit_cast<T>(v);
 		}
 
@@ -609,7 +623,7 @@ namespace zero_cost_serialization {
 			alignas(T) std::array<std::byte, sizeof(T)> v;
 			static_assert(std::has_unique_object_representations_v<decltype(v)>);
 			v = std::bit_cast<decltype(v)>(t);
-			std::ranges::copy(v, std::span(s). template subspan<N, sizeof(T)>().data());
+			std::ranges::copy(v, std::span(s). template subspan<N, sizeof(T)>().begin());
 		}
 	};
 	namespace detail {
@@ -639,8 +653,10 @@ namespace zero_cost_serialization {
 	struct is_serializable_type<B, Traits> {
 		constexpr auto operator()(bool& result, std::size_t& offset, std::size_t& align) noexcept
 		{
-			if constexpr (not std::has_unique_object_representations_v<B>) result = false;
-			else if (offset % alignof(B)) result = false;
+			if constexpr (not std::has_unique_object_representations_v<B>)
+				result = false;
+			else if (offset % alignof(B))
+				result = false;
 			else {
 				offset += sizeof(B);
 				align = std::max(align, alignof(B));

--- a/include/zero_cost_serialization/interchange_float.h
+++ b/include/zero_cost_serialization/interchange_float.h
@@ -27,7 +27,7 @@ namespace zero_cost_serialization {
 			constexpr auto m_mask = T{ i_bit - 1 };
 			constexpr auto m_max = i_bit | m_mask;
 
-			if (auto exceeds_m = std::bit_width(static_cast<std::make_unsigned_t<T>>(t)) - M; exceeds_m > 0) [[unlikely]] {
+			if (auto exceeds_m = std::bit_width(static_cast<std::make_unsigned_t<T>>(t)) - M; exceeds_m > 0) {
 				auto odd_bit = T{ 1 } << exceeds_m;
 				auto half = odd_bit >> 1;
 				auto is_odd = bool(odd_bit & t);
@@ -138,7 +138,7 @@ namespace zero_cost_serialization {
 			if (std::isfinite(f)) {
 				auto e = int{};
 				t = T(std::abs(std::rint(std::ldexp(std::frexp(f, &e), M))));
-				
+
 				detail::round_to_even<M>(t, e);
 
 				if (e > e_max)

--- a/include/zero_cost_serialization/serializable.h
+++ b/include/zero_cost_serialization/serializable.h
@@ -149,12 +149,18 @@ namespace zero_cost_serialization {
 	template <detail::reflectable_scalar S, typename Traits>
 	struct is_serializable_type<S, Traits> { constexpr auto operator()(bool& result, std::size_t& offset, std::size_t& align) noexcept
 	{
-		if constexpr (not Traits:: template is_representation_compatible<S>()) result = false;
-		else if constexpr (std::popcount(Traits:: template minimum_alignment<S>()) != 1) result = false;
-		else if constexpr (sizeof(S) % alignof(S)) result = false;
-		else if constexpr (sizeof(S) % Traits:: template minimum_alignment<S>()) result = false;
-		else if (offset % alignof(S)) result = false;
-		else if (offset % Traits:: template minimum_alignment<S>()) result = false;
+		if constexpr (not Traits:: template is_representation_compatible<S>())
+			result = false;
+		else if constexpr (std::popcount(Traits:: template minimum_alignment<S>()) != 1)
+			result = false;
+		else if constexpr (sizeof(S) % alignof(S))
+			result = false;
+		else if constexpr (sizeof(S) % Traits:: template minimum_alignment<S>())
+			result = false;
+		else if (offset % alignof(S))
+			result = false;
+		else if (offset % Traits:: template minimum_alignment<S>())
+			result = false;
 		else {
 			offset += sizeof(S);
 			align = std::max({align, Traits:: template minimum_alignment<S>(), alignof(S)});
@@ -176,10 +182,14 @@ namespace zero_cost_serialization {
 		auto arr_align = std::size_t{ 1 };
 		using E = std::remove_all_extents_t<A>;
 		is_serializable_type<E, Traits>{}(result, arr_off, arr_align);
-		if (arr_off not_eq sizeof(E)) result = false;
-		else if (arr_off % arr_align) result = false;
-		else if (offset % arr_align) result = false;
-		else if (offset % alignof(A)) result = false;
+		if (arr_off not_eq sizeof(E))
+			result = false;
+		else if (arr_off % arr_align)
+			result = false;
+		else if (offset % arr_align)
+			result = false;
+		else if (offset % alignof(A))
+			result = false;
 		else {
 			offset += sizeof(A);
 			align = std::max({ align, arr_align, alignof(A) });
@@ -192,10 +202,14 @@ namespace zero_cost_serialization {
 		auto class_off = std::size_t{};
 		auto class_align = std::size_t{ 1 };
 		detail::is_serializable_member<C, Traits>(std::make_index_sequence<detail::field_count<C>()>(), result, class_off, class_align);
-		if (class_off not_eq sizeof(C)) result = false;
-		else if (class_off % class_align) result = false;
-		else if (offset % class_align) result = false;
-		else if (offset % alignof(C)) result = false;
+		if (class_off not_eq sizeof(C))
+			result = false;
+		else if (class_off % class_align)
+			result = false;
+		else if (offset % class_align)
+			result = false;
+		else if (offset % alignof(C))
+			result = false;
 		else {
 			offset += sizeof(C);
 			align = std::max({ align, class_align, alignof(C) });

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -159,7 +159,7 @@ auto test() noexcept
 		std::ranges::for_each(p, [](float f) { std::cout << f << std::endl; });
 	};
 	alignas(Ts...) std::byte buf[12]{};
-	std::memcpy(buf, "hello world", sizeof(buf));
+	std::ranges::copy(std::as_bytes(std::span("hello world")), buf);
 	return zero_cost_serialization::invoke<Ts...>(fun, std::forward_as_tuple("hello"), buf);
 }
 
@@ -239,7 +239,7 @@ int main()
 		std::ranges::for_each(a, [](float ff) { std::cout << ff << std::endl; });
 		return 73;
 	}; //std::uint32_t and exactly 2 floats.
-	std::memcpy(buf, "hello world", sizeof(buf));
+	std::ranges::copy(std::as_bytes(std::span("hello world")), buf);
 	static_assert(zero_cost_serialization::apply_size_v<foobar, decltype(fun)> == 12);
 	static_assert(zero_cost_serialization::flex_element_size_v<foobar, decltype(fun)> == 0);
 	assert(73 == zero_cost_serialization::apply<foobar>(fun, buf));
@@ -248,7 +248,7 @@ int main()
 		std::cout << uu << std::endl;
 		std::ranges::for_each(p, [](float ff) { std::cout << ff << std::endl; });
 	}; //std::uint32_t and 0+ floats.
-	std::memcpy(buf, "flex array!", sizeof(buf));
+	std::ranges::copy(std::as_bytes(std::span("flex array!")), buf);
 	static_assert(zero_cost_serialization::apply_size_v<foobar, decltype(fun2)> == 4);
 	static_assert(zero_cost_serialization::flex_element_size_v<foobar, decltype(fun2)> == 4);
 	zero_cost_serialization::apply<foobar>(fun2, buf);

--- a/tools/codegen.cpp
+++ b/tools/codegen.cpp
@@ -1,7 +1,8 @@
 #include <array>
 #include <concepts>
 #include <cstddef>
-#include <cstdio>
+#include <format>
+#include <iostream>
 #include <span>
 #include <string_view>
 #include <type_traits>
@@ -76,39 +77,39 @@ int main()
 {
 	constexpr auto n = 255;
 
-	puts("#ifndef C17AB45F97AA4A1EAF3129E2BA17DE70");
-	puts("#define C17AB45F97AA4A1EAF3129E2BA17DE70");
-	puts("#ifdef C17AB45F97AA4A1EAF3129E2BA17DE70");
-	puts("");
-	puts("#include <cstddef>");
-	puts("#include <tuple>");
-	puts("#include <type_traits>");
-	puts("");
-	puts("namespace zero_cost_serialization::detail {");
-	puts("\ttemplate <typename, std::size_t, typename = void>\n\tstruct init_n : std::false_type {};");
-	puts("");
+	std::cout << "#ifndef C17AB45F97AA4A1EAF3129E2BA17DE70" << '\n';
+	std::cout << "#define C17AB45F97AA4A1EAF3129E2BA17DE70" << '\n';
+	std::cout << "#ifdef C17AB45F97AA4A1EAF3129E2BA17DE70" << '\n';
+	std::cout << "" << '\n';
+	std::cout << "#include <cstddef>" << '\n';
+	std::cout << "#include <tuple>" << '\n';
+	std::cout << "#include <type_traits>" << '\n';
+	std::cout << "" << '\n';
+	std::cout << "namespace zero_cost_serialization::detail {" << '\n';
+	std::cout << "\ttemplate <typename, std::size_t, typename = void>\n\tstruct init_n : std::false_type {};" << '\n';
+	std::cout << "" << '\n';
 	for (auto i = 0; i not_eq n + 1; ++i)
-		printf("\ttemplate <typename T>\n\tstruct init_n<T, std::size_t{%i}, std::void_t<decltype(T(%.*s))>> : std::true_type {};\n\n", i, i ? i * 3 - 1 : 0, braces<n>);
-	puts("\ttemplate <typename T, typename = void>\n\tstruct make_tuple { constexpr auto operator()(T&) const noexcept\n\t{\n\t\treturn std::make_tuple();\n\t}};\n");
+		std::cout << std::format("\ttemplate <typename T>\n\tstruct init_n<T, std::size_t{{{}}}, std::void_t<decltype(T({:.{}s}))>> : std::true_type {{}};\n\n", i, braces<n>, i ? i * 3 - 1 : 0);
+	std::cout << "\ttemplate <typename T, typename = void>\n\tstruct make_tuple { constexpr auto operator()(T&) const noexcept\n\t{\n\t\treturn std::make_tuple();\n\t}};\n" << '\n';
 	for (auto i = 0, j = digits_n(i) + 1; i not_eq n; j += digits_n(i) + 2)
-		printf("\ttemplate <typename T>\n\tstruct make_tuple<T, std::integral_constant<std::size_t, std::size_t{%i}>> { [[maybe_unused, nodiscard]] constexpr auto operator()(T& t) const noexcept \n\t{\n\t\tauto& [%.*s] = t;\n\t\treturn std::tie(%.*s);\n\t}};\n\n",
-			++i, j, make_binds<n>().data(), j, make_binds<n>().data());
-	puts("\ttemplate <typename T, std::size_t... Is>");
-	puts("\t[[nodiscard]] consteval auto field_count(const std::index_sequence<Is...>&) noexcept");
-	puts("\t{");
-	puts("\t\tauto n = std::size_t{};");
-	puts("\t\t((n = init_n<T, Is>::value ? Is : n), ...);");
-	puts("\t\treturn n;");
-	puts("\t}");
-	puts("");
-	puts("\ttemplate <typename T>");
-	puts("\t[[nodiscard]] consteval auto field_count() noexcept");
-	puts("\t{");
-	printf("\t\treturn field_count<T>(std::make_index_sequence<%d>());\n", n + 1);
-	puts("\t}");
-	puts("}");
-	puts("");
-	puts("#endif");
-	puts("#endif");
+		std::cout << std::format("\ttemplate <typename T>\n\tstruct make_tuple<T, std::integral_constant<std::size_t, std::size_t{{{}}}>> {{ [[maybe_unused, nodiscard]] constexpr auto operator()(T& t) const noexcept \n\t{{\n\t\tauto& [{:.{}s}] = t;\n\t\treturn std::tie({:.{}s});\n\t}}}};\n\n",
+			++i, make_binds<n>().data(), j, make_binds<n>().data(), j);
+	std::cout << "\ttemplate <typename T, std::size_t... Is>" << '\n';
+	std::cout << "\t[[nodiscard]] consteval auto field_count(const std::index_sequence<Is...>&) noexcept" << '\n';
+	std::cout << "\t{" << '\n';
+	std::cout << "\t\tauto n = std::size_t{};" << '\n';
+	std::cout << "\t\t((n = init_n<T, Is>::value ? Is : n), ...);" << '\n';
+	std::cout << "\t\treturn n;" << '\n';
+	std::cout << "\t}" << '\n';
+	std::cout << "" << '\n';
+	std::cout << "\ttemplate <typename T>" << '\n';
+	std::cout << "\t[[nodiscard]] consteval auto field_count() noexcept" << '\n';
+	std::cout << "\t{" << '\n';
+	std::cout << std::format("\t\treturn field_count<T>(std::make_index_sequence<{}>());\n", n + 1);
+	std::cout << "\t}" << '\n';
+	std::cout << "}" << '\n';
+	std::cout << "" << '\n';
+	std::cout << "#endif" << '\n';
+	std::cout << "#endif" << '\n';
 	return 0;
 }


### PR DESCRIPTION
prefer .begin() to .data() when .begin() is valid.
prefer std::format to printf.
prefer std::ranges::copy to std::memcpy and std:memmove when we don't need the properties of the C library functions.